### PR TITLE
#Add: 活動計画作成時にfirestorageへの画像ファイルの追加処理を作成

### DIFF
--- a/components/ActivityPlans/AddActivityPlan.vue
+++ b/components/ActivityPlans/AddActivityPlan.vue
@@ -24,6 +24,7 @@ export default {
       default: () => ({
         category: '',
         detail: '',
+        imageFile: null,
         date: new Date().toISOString().substr(0, 10),
         done: false
       })

--- a/components/ActivityPlans/UpdateActivityPlan.vue
+++ b/components/ActivityPlans/UpdateActivityPlan.vue
@@ -8,6 +8,9 @@
       @close-activity-plan="closeUpdateActivityPlan"
       @save-activity-plan="handleUpdateActivityPlan"
     >
+      <template v-slot:imageFile v-if="editPlanContents.photoURL">
+        <v-img :src="editPlanContents.photoURL" :lazy-src="editPlanContents.photoURL"> </v-img>
+      </template>
       <template v-slot:comment>
         <AddComment :plan-contents-id="editPlanContents.id" />
         <Comment :planContents-id="editPlanContents.id" />

--- a/components/commonParts/activityPlans/form/FormCreateActivityPlan.vue
+++ b/components/commonParts/activityPlans/form/FormCreateActivityPlan.vue
@@ -16,10 +16,10 @@
                 <v-col cols="12">
                   <DetailForm :detail.sync="planContents.detail" />
                 </v-col>
-                <v-col>
-                  <InChangeForm
-                    :in-charge-member.sync="planContents.inChargeMember"
-                    :items="gettersTeamMember"
+                <v-col cols="12" sm="12" md="12">
+                  <InputFile
+                    :imageFile.sync="planContents.imageFile"
+                    @change-image-file="changeImageFile"
                   />
                 </v-col>
                 <slot name="comment"></slot>
@@ -48,6 +48,7 @@ import DetailForm from '@/components/commonParts/activityPlans/input/DetailForm'
 import DateForm from '@/components/commonParts/activityPlans/input/DateForm'
 import InChangeForm from '@/components/commonParts/activityPlans/input/InChargeForm'
 import FormView from '@/components/commonParts/form/FormView'
+import InputFile from '@/components/commonParts/form/InputFile'
 
 export default {
   components: {
@@ -57,18 +58,20 @@ export default {
     DetailForm,
     DateForm,
     InChangeForm,
-    FormView
+    FormView,
+    InputFile
   },
 
   props: {
     title: String,
     planContents: {
       type: Object,
-      required: false,
+      required: true,
       default: () => ({
         category: '',
         detail: '',
         inChargeMember: [],
+        imageFile: null,
         date: new Date().toISOString().substr(0, 10),
         done: false
       })
@@ -104,6 +107,9 @@ export default {
     },
     inputDate() {
       this.dateMenu = false
+    },
+    changeImageFile(file) {
+      this.planContents.imageFile = file
     }
   }
 }

--- a/components/commonParts/activityPlans/form/FormCreateActivityPlan.vue
+++ b/components/commonParts/activityPlans/form/FormCreateActivityPlan.vue
@@ -17,6 +17,7 @@
                   <DetailForm :detail.sync="planContents.detail" />
                 </v-col>
                 <v-col cols="12" sm="12" md="12">
+                  <slot name="imageFile"></slot>
                   <InputFile
                     :imageFile.sync="planContents.imageFile"
                     @change-image-file="changeImageFile"

--- a/components/commonParts/form/InputFile.vue
+++ b/components/commonParts/form/InputFile.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <v-file-input
+      ref="image"
+      v-model="innerImageFile"
+      accept="image/*"
+      show-size
+      label="画像ファイル"
+      prepend-icon="mdi-file-image-outline"
+      @change="changeImageFile"
+    >
+      <template v-slot:selection="{ text }">
+        <v-chip small label color="blue darken-1" class="font-italic white--text">
+          <span>
+            {{ text }}
+          </span>
+        </v-chip>
+      </template>
+    </v-file-input>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    imageFile: {
+      type: null,
+      required: false,
+      default: null
+    }
+  },
+  computed: {
+    innerImageFile: {
+      get() {
+        return this.imageFile
+      },
+      set(imageFile) {
+        this.$emit('update:image-file', imageFile)
+      }
+    }
+  },
+  methods: {
+    // 画像をクリックしした時にv-file-inputでファイルを選択できるようにする
+    selectUserImageFile() {
+      this.$refs.image.$refs.input.click()
+    },
+    changeImageFile(event) {
+      const file = event
+      this.$emit('change-image-file', file)
+    }
+  }
+}
+</script>

--- a/pages/activityPlans.vue
+++ b/pages/activityPlans.vue
@@ -102,6 +102,7 @@ export default {
         category: null,
         detail: '',
         inChargeMember: [],
+        imageFile: null,
         date: new Date().toISOString().substr(0, 10),
         done: false
       },


### PR DESCRIPTION
活動計画作成時にfirestorageへ画像ファイルを追加できるようにしました。
削除、更新は別のissueで行います。