### PR TITLE
#477 Add: チームが削除された時にメンバーと活動計画のデータも全て消すようにする

### DIFF
--- a/store/modules/activityPlans/activityPlans.js
+++ b/store/modules/activityPlans/activityPlans.js
@@ -134,6 +134,16 @@ const actions = {
       commit('removeActivityPlan', { activityPlanId })
     }
   },
+  async allRemoveActivityPlan({ commit, getters }) {
+    const snapShot = await db
+      .collection(`users/${getters.userUid}/activityPlans`)
+      .orderBy('created', 'desc')
+      .get()
+    snapShot.docs.map(async (doc) => {
+      await db.collection(`users/${getters.userUid}/activityPlans`).doc(doc.id).delete()
+      commit('initActivityPlans')
+    })
+  },
   // 活動計画の完了状態切り替え
   async doneActivityPlan({ getters, commit }, { planContents, id }) {
     await db.collection(`users/${getters.userUid}/activityPlans`).doc(id).update({

--- a/store/modules/team/team.js
+++ b/store/modules/team/team.js
@@ -131,7 +131,7 @@ const actions = {
     try {
       await db.collection(`users/${getters.userUid}/team`).doc(id).delete()
       await commit('removeTeam', id)
-      await dispatch('allRemoveMember', id)
+      await dispatch('modules/activityPlans/activityPlans/allRemoveActivityPlan', null, { root: true })
     } catch (err) {
       alert('削除に失敗しました。もう一度やり直してください')
       console.log(err)

--- a/store/modules/team/team.js
+++ b/store/modules/team/team.js
@@ -197,6 +197,14 @@ const actions = {
       console.log(err)
     }
   },
+  async allRemoveMember({ commit, getters }) {
+    const snapShot = await db.collection(`users/${getters.userUid}/team`).doc(getters.teamId).get()
+    const subCollection = await snapShot.ref.collection('teamMember').get()
+    subCollection.docs.map(async (doc) => {
+      snapShot.ref.collection('teamMember').doc(doc.id).delete()
+    })
+    commit('initMember')
+  }
 }
 
 const getters = {

--- a/store/modules/team/team.js
+++ b/store/modules/team/team.js
@@ -126,11 +126,12 @@ const actions = {
     team.photoURL = photoURL
     dispatch('updateTeam', team)
   },
-  async removeTeam({ commit, getters }) {
+  async removeTeam({ commit, dispatch, getters }) {
     const id = getters.teamId
     try {
       await db.collection(`users/${getters.userUid}/team`).doc(id).delete()
-      commit('removeTeam', id)
+      await commit('removeTeam', id)
+      await dispatch('allRemoveMember', id)
     } catch (err) {
       alert('削除に失敗しました。もう一度やり直してください')
       console.log(err)
@@ -197,8 +198,8 @@ const actions = {
       console.log(err)
     }
   },
-  async allRemoveMember({ commit, getters }) {
-    const snapShot = await db.collection(`users/${getters.userUid}/team`).doc(getters.teamId).get()
+  async allRemoveMember({ commit, getters }, id) {
+    const snapShot = await db.collection(`users/${getters.userUid}/team`).doc(id).get()
     const subCollection = await snapShot.ref.collection('teamMember').get()
     subCollection.docs.map(async (doc) => {
       snapShot.ref.collection('teamMember').doc(doc.id).delete()


### PR DESCRIPTION
 チームが削除された時にメンバーと活動計画のデータも全て消すように処理を追記しました。