### PR TITLE
#475 Fix:チーム作成時における画像ファイルの有無による条件分岐処理の修正

### DIFF
--- a/components/team/CreateTeam.vue
+++ b/components/team/CreateTeam.vue
@@ -21,7 +21,9 @@ export default {
     return {
       createTeam: {
         name: '',
-        imageFile: null
+        imageFile: null,
+        fileName: '',
+        photoURL: ''
       }
     }
   },


### PR DESCRIPTION
チーム作成時に使用するデータの初期値にfilenameとphotoURLがなかったため追加の修正をしました。