### PR TITLE
#482 Fix:条件分岐により引数のeventがある場合のみ動くように修正

### DIFF
--- a/components/commonParts/form/InputFile.vue
+++ b/components/commonParts/form/InputFile.vue
@@ -45,8 +45,10 @@ export default {
       this.$refs.image.$refs.input.click()
     },
     changeImageFile(event) {
-      const file = event
-      this.$emit('change-image-file', file)
+      if (event) {
+        const file = event
+        this.$emit('change-image-file', file)
+      }
     }
   }
 }


### PR DESCRIPTION
v-file-inputのchangeイベントが必要以上に動いてしまうため、条件分岐により引数のeventがある場合のみ動くように修正