### PR TITLE
#494 Add: 活動計画のカード表示コンポーネントを作成

### DIFF
--- a/components/ActivityPlans/ActivityPlansCard.vue
+++ b/components/ActivityPlans/ActivityPlansCard.vue
@@ -75,6 +75,9 @@ export default {
     },
     toggleDoneActivityPlan(contents) {
       this.$emit('toggle-done-activity-plan', contents)
+    },
+    openActivityPlan(contents) {
+      this.$emit('open-activity-plan', contents)
     }
   }
 }

--- a/components/ActivityPlans/ActivityPlansCard.vue
+++ b/components/ActivityPlans/ActivityPlansCard.vue
@@ -17,9 +17,29 @@
 
             <v-card-subtitle v-text="contents.date" class="pb-0 mt-1"></v-card-subtitle>
             <v-spacer />
-            <v-btn icon>
-              <v-icon @click="handleRemoveActivityPlan(contents)">mdi-delete-outline</v-icon>
-            </v-btn>
+            <v-menu transition="slide-y-transition" bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <v-btn icon v-bind="attrs" v-on="on">
+                  <v-icon> mdi-dots-vertical</v-icon>
+                </v-btn>
+              </template>
+              <v-list>
+                <v-list-item class="px-0">
+                  <v-list-item-title>
+                    <v-btn text @click="openActivityPlan(contents)">
+                      <v-icon>mdi-pencil-outline </v-icon>編集
+                    </v-btn>
+                  </v-list-item-title>
+                </v-list-item>
+                <v-list-item class="px-0">
+                  <v-list-item-title>
+                    <v-btn text @click="handleRemoveActivityPlan(contents)">
+                      <v-icon>mdi-delete-outline</v-icon>削除
+                    </v-btn>
+                  </v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
           </v-card-actions>
 
           <v-card-actions>

--- a/components/ActivityPlans/ActivityPlansCard.vue
+++ b/components/ActivityPlans/ActivityPlansCard.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-col cols="12">
+    <template v-for="contents in displayActivityPlans">
+      <transition :key="contents.catgorys" name="list">
+        <v-card class="mb-2">
+          <v-card-actions>
+            <v-btn icon @click="toggleDoneActivityPlan(contents)">
+              <v-icon :class="(!contents.done && 'grey--text') || 'primary--text'"
+                >mdi-check-circle-outline
+              </v-icon>
+            </v-btn>
+            <v-card-title
+              :class="(contents.done && 'grey--text') || 'black--text'"
+              class="headline pa-0"
+              v-text="contents.category"
+            ></v-card-title>
+
+            <v-card-subtitle v-text="contents.date" class="pb-0 mt-1"></v-card-subtitle>
+            <v-spacer />
+            <v-btn icon>
+              <v-icon @click="handleRemoveActivityPlan(contents)">mdi-delete-outline</v-icon>
+            </v-btn>
+          </v-card-actions>
+
+          <v-card-actions>
+            <v-card-subtitle v-text="contents.detail" class="py-0 mt-1"></v-card-subtitle>
+          </v-card-actions>
+          <v-card-actions>
+            <v-card-subtitle v-text="contents.inChargeMember" class="py-0 mt-1"></v-card-subtitle>
+          </v-card-actions>
+        </v-card>
+      </transition>
+    </template>
+  </v-col>
+</template>
+
+<script>
+export default {
+  props: {
+    displayActivityPlans: {
+      type: Array,
+      required: true
+    }
+  },
+  methods: {
+    handleRemoveActivityPlan(contents) {
+      this.$emit('handle-remove-activity-plan', contents)
+    },
+    toggleDoneActivityPlan(contents) {
+      this.$emit('toggle-done-activity-plan', contents)
+    }
+  }
+}
+</script>

--- a/components/ActivityPlans/ActivityPlansCard.vue
+++ b/components/ActivityPlans/ActivityPlansCard.vue
@@ -27,6 +27,13 @@
           </v-card-actions>
           <v-card-actions>
             <v-card-subtitle v-text="contents.inChargeMember" class="py-0 mt-1"></v-card-subtitle>
+            <v-spacer />
+            <v-btn icon>
+              <v-icon> mdi-file-image-outline </v-icon>
+            </v-btn>
+            <v-btn icon>
+              <v-icon>mdi-comment-text-outline </v-icon>
+            </v-btn>
           </v-card-actions>
         </v-card>
       </transition>

--- a/components/ActivityPlans/ActivityPlansCard.vue
+++ b/components/ActivityPlans/ActivityPlansCard.vue
@@ -82,3 +82,15 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.list-enter-active,
+.list-leave-active {
+  transition: all 0.8s;
+}
+.list-enter,
+.list-leave-to {
+  opacity: 0;
+  transform: translateX(100%);
+}
+</style>

--- a/components/ActivityPlans/ActivityPlansCard.vue
+++ b/components/ActivityPlans/ActivityPlansCard.vue
@@ -11,7 +11,7 @@
             </v-btn>
             <v-card-title
               :class="(contents.done && 'grey--text') || 'black--text'"
-              class="headline pa-0"
+              class="pa-0"
               v-text="contents.category"
             ></v-card-title>
 

--- a/components/ActivityPlans/ActivityPlansTable.vue
+++ b/components/ActivityPlans/ActivityPlansTable.vue
@@ -26,15 +26,6 @@ export default {
   },
   props: {
     displayActivityPlans: {
-      type: Array
-    },
-    searchActivityPlans: {
-      type: Array
-    },
-    sortByActivityPlans: {
-      type: Array
-    },
-    displayActivityPlans: {
       type: Array,
       required: true
     },
@@ -45,22 +36,9 @@ export default {
   },
   data() {
     return {
-      planContentsHeaders: [
-        { text: '状態', value: 'done', align: 'start', sortable: false },
-        {
-          text: ' カテゴリ',
-          value: 'category',
-          sortable: false
-        },
-        { text: '期限', value: 'date' },
-        { text: '削除', value: 'remove', sortable: false }
-      ],
       editPlanContents: {},
       updateActivityPlanDialog: false
     }
-  },
-  computed: {
-    ...mapState('modules/activityPlans/activityPlans', ['activityPlans'])
   },
   methods: {
     handleRemoveActivityPlan(contents) {

--- a/components/ActivityPlans/ActivityPlansTable.vue
+++ b/components/ActivityPlans/ActivityPlansTable.vue
@@ -88,14 +88,3 @@ export default {
 }
 </script>
 
-<style>
-.list-enter-active,
-.list-leave-active {
-  transition: all 0.8s;
-}
-.list-enter,
-.list-leave-to {
-  opacity: 0;
-  transform: translateY(100%);
-}
-</style>

--- a/components/ActivityPlans/ActivityPlansTable.vue
+++ b/components/ActivityPlans/ActivityPlansTable.vue
@@ -1,57 +1,10 @@
 <template>
   <div>
-    <v-card>
-      <v-simple-table fixed-header>
-        <template v-slot:default>
-          <thead>
-            <tr>
-              <th class="text-left">状態</th>
-              <th class="text-left">やること</th>
-              <th class="text-left">日付</th>
-              <th class="text-left">削除</th>
-            </tr>
-          </thead>
-          <tbody>
-            <template v-for="contents in displayActivityPlans">
-              <transition :key="contents.catgorys" name="list">
-                <tr>
-                  <td>
-                    <v-btn icon @click="toggleDoneActivityPlan(contents)">
-                      <v-icon :class="(!contents.done && 'grey--text') || 'primary--text'"
-                        >mdi-check-circle-outline</v-icon
-                      >
-                    </v-btn>
-                  </td>
-                  <v-tooltip bottom>
-                    <template v-slot:activator="{ on, attrs }">
-                      <td
-                        v-bind="attrs"
-                        :class="(contents.done && 'grey--text') || 'primary--text'"
-                        v-on="on"
-                        @click="openUpdateActivityPlan(contents)"
-                      >
-                        {{ contents.category }}
-                      </td>
-                    </template>
-                    <span>{{ contents.category }}の詳細を開く</span>
-                  </v-tooltip>
-                  <td :class="(contents.done && 'grey--text') || 'black--text'" class="pa-0">
-                    {{ contents.date }}
-                  </td>
-                  <td>
-                    <v-btn icon>
-                      <v-icon @click="handleRemoveActivityPlan(contents)"
-                        >mdi-delete-outline</v-icon
-                      >
-                    </v-btn>
-                  </td>
-                </tr>
-              </transition>
-            </template>
-          </tbody>
-        </template>
-      </v-simple-table>
-    </v-card>
+    <ActivityPlansCard
+      :display-activity-plans="displayActivityPlans"
+      @toggle-done-activity-plan="toggleDoneActivityPlan"
+      @handle-remove-activity-plan="handleRemoveActivityPlan"
+    />
     <UpdateActivityPlan
       :edit-plan-contents="editPlanContents"
       :todo-categorys="todoCategorys"
@@ -64,9 +17,11 @@
 <script>
 import { mapState, mapActions } from 'vuex'
 import UpdateActivityPlan from '@/components/ActivityPlans/UpdateActivityPlan'
+import ActivityPlansCard from '@/components/ActivityPlans/ActivityPlansCard'
 export default {
   components: {
-    UpdateActivityPlan
+    UpdateActivityPlan,
+    ActivityPlansCard
   },
   props: {
     displayActivityPlans: {
@@ -112,7 +67,6 @@ export default {
       this.removeActivityPlan({ id: contents.id })
     },
     toggleDoneActivityPlan(contents) {
-      console.log(contents)
       this.doneActivityPlan({ planContents: contents, id: contents.id })
     },
     async openUpdateActivityPlan(contents) {

--- a/components/ActivityPlans/ActivityPlansTable.vue
+++ b/components/ActivityPlans/ActivityPlansTable.vue
@@ -4,6 +4,7 @@
       :display-activity-plans="displayActivityPlans"
       @toggle-done-activity-plan="toggleDoneActivityPlan"
       @handle-remove-activity-plan="handleRemoveActivityPlan"
+      @open-activity-plan="openUpdateActivityPlan"
     />
     <UpdateActivityPlan
       :edit-plan-contents="editPlanContents"

--- a/pages/activityPlans.vue
+++ b/pages/activityPlans.vue
@@ -59,9 +59,6 @@
         :activity-plans-page-length="activityPlansPageLength"
       />
       <ActivityPlansTable
-        :activityPlansFiltered="activityPlansFiltered"
-        :searchActivityPlans="searchActivityPlans"
-        :sortByActivityPlans="sortByActivityPlans"
         :display-activity-plans="displayActivityPlans"
         :todo-categorys="todoCategorys"
       />


### PR DESCRIPTION
活動計画のカード表示コンポーネントを作成して、表示をてテーブルからカードに切り替える。