### PR TITLE
#506 Add: 画像がある場合は1を表示させてない場合は表示なしになるように処理を追加

### DIFF
--- a/components/ActivityPlans/ActivityPlansCard.vue
+++ b/components/ActivityPlans/ActivityPlansCard.vue
@@ -53,6 +53,7 @@
             <v-card-subtitle v-text="contents.inChargeMember" class="py-0 mt-1"></v-card-subtitle>
             <v-spacer />
             <IconButton :icon="'mdi-file-image-outline'" />
+            {{ contents.photoURL ? '1' : '' }}
             <IconButton :icon="'mdi-comment-text-outline '" />
           </v-card-actions>
         </v-card>
@@ -83,6 +84,7 @@ export default {
       this.$emit('toggle-done-activity-plan', contents)
     },
     openActivityPlan(contents) {
+      console.log(contents)
       this.$emit('open-activity-plan', contents)
     }
   }


### PR DESCRIPTION
活動計画の画像ファイルの有無で表示を変える処理を追加しました。