### PR TITLE
#509 Fix: 検索キーワードがnullになった場合はsortByActivityPlansを返すように修正

### DIFF
--- a/pages/activityPlans.vue
+++ b/pages/activityPlans.vue
@@ -174,7 +174,7 @@ export default {
       const activityPlans = this.sortByActivityPlans
       const searchCategory = this.searchCategoryKeyword
       if (this.searchCategoryKeyword === null) {
-        return this.activityPlans
+        return this.sortByActivityPlans
       }
 
       return activityPlans.filter((activityPlan) => {


### PR DESCRIPTION
検索キーワードがnullになった後にstateのactivityPlansを返していたが、その後ソート機能が動かなくなるため修正しました。