### PR TITLE
#558 firestoreからのデータの取得処理を修正

### DIFF
--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -1,6 +1,8 @@
 import { auth } from '../plugins/firebase'
 
-export default function ({ store, redirect, route }) {
+export default function ({ store, redirect }) {
+  if (store.state.modules.user.auth.loginUser !== null) return
+
   auth.onAuthStateChanged((user) => {
     if (user) {
       const userInfo = {
@@ -11,11 +13,6 @@ export default function ({ store, redirect, route }) {
       }
       // ログインユーザーの情報をstateに入れる
       store.dispatch('modules/user/auth/setLoginUser', userInfo)
-      // firestoreかデータを取得する
-      store.dispatch('modules/activityPlans/activityPlans/fetchActivityPlans')
-      store.dispatch('modules/team/team/fetchTeam')
-    } else if (route.path === '/signIn') {
-      return redirect('/')
     } else {
       return redirect('/signIn')
     }

--- a/store/modules/user/auth.js
+++ b/store/modules/user/auth.js
@@ -20,20 +20,22 @@ const mutations = {
 
 const actions = {
   // ログインユーザー情報の取得
-  setLoginUser({ commit }, userInfo) {
-    commit('setLoginUser', userInfo)
+  async setLoginUser({ commit, dispatch }, userInfo) {
+    await commit('setLoginUser', userInfo)
+    dispatch('modules/activityPlans/activityPlans/fetchActivityPlans', null, { root: true })
+    dispatch('modules/team/team/fetchTeam', null, { root: true })
+
   },
   // ログインユーザー情報の削除
   deleteLoginUser({ commit }) {
     commit('deleteLoginUser')
   },
   // Googleログイン
-  async googleLogin({ commit }) {
+  async googleLogin() {
     try {
       const provider = new firebase.auth.GoogleAuthProvider()
       await auth.signInWithPopup(provider).then((result) => {
         alert('ようこそ ' + result.user.displayName + 'さん!')
-        commit('setLoginUser')
         this.$router.push({ path: '/' })
       })
     } catch (err) {
@@ -46,7 +48,6 @@ const actions = {
       await firebase.auth().signInWithEmailAndPassword(email, password)
       const userInfo = await firebase.auth().currentUser
       alert('ようこそ' + userInfo.displayName + 'さん!')
-      commit('setLoginUser', userInfo)
       // サインイン成功後にトップページに遷移する
       this.$router.push({ path: '/' })
     } catch {


### PR DESCRIPTION
middlewareログイン後に取得をしていたため取得処理が必要以上に呼び出される。
そのため、ログイン後ユーザー情報を更新した後に呼び出すように変更