### PR TITLE
#610 メンバー編集のフォームに枠割がうまく表示されていない

### DIFF
--- a/components/circle/AddMemberDialog.vue
+++ b/components/circle/AddMemberDialog.vue
@@ -22,6 +22,7 @@
             v-model="addMemberInput.role"
             :items="circleRoles"
             :rules="$rules.role"
+            multiple
             icon="mdi-briefcase-account-outline"
             label="役割"
           />
@@ -45,7 +46,6 @@
       <AppButton :loading="isRunning" :disabled="!isValid" @click="runAddMember">保存する </AppButton>
       <AppButton :disabled="isRunning" color="success" outlined @click="$emit('close', false)">キャンセル </AppButton>
     </template>
-    <v-divider />
   </AppDialog>
 </template>
 


### PR DESCRIPTION
# レビュー観点
- メンバー編集時にフォームに役割がうまく表示されていない
# 動作確認実施項目
- 役割登録時に配列で作成されていなかったため、複数選択可にして配列が作成できるようになっている