### PR TITLE
612-パスワード再設定メールが届かない

### DIFF
--- a/components/account/ResetPasswordDialog.vue
+++ b/components/account/ResetPasswordDialog.vue
@@ -66,9 +66,9 @@ export default {
   methods: {
     // パスワードリセット実行
     async runResetPassword() {
+      // ローディングをON
+      this.isRunning = true
       if (this.resetUserPasswordInput.email === 'test@example.com') {
-        // ローディングをON
-        this.isRunning = true
         alert('テストユーザーはパスワードを再設定することはできません')
         return
       }


### PR DESCRIPTION
# レビュー観点
- パスワード再設定メールが届くようになっているか
# 動作確認実施項目
- [x] 10分メールでは確認できなかったが、gmailでは確認が取れた
# その他
- リセットパスワードを実行した時に、ボタンのローディングが機能していなかったため、そこだけ修正